### PR TITLE
fix: change Swagger dependency version

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2'
 	implementation 'org.mybatis:mybatis:3.5.13'
 	// Swagger
-	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
스웨거로 api 테스트 시, uri가 String에서 int로 변환이 되지 않는 문제가 발생하여 스웨거 버전 업데이트로 해결함